### PR TITLE
WINDUPRULE-344 enhancements to XSLT and script

### DIFF
--- a/scripts/tests/create-tests.xslt
+++ b/scripts/tests/create-tests.xslt
@@ -7,12 +7,13 @@
 <xsl:param name="testDataPath" />
 <xsl:param name="testFileStub"/>
 <xsl:param name="outputDirectory"/>
+<xsl:variable name="rulesetId" select="/windup:ruleset/@id"/>
 
 <xsl:output method="xml" indent="yes"/>
 
 
 <xsl:template match="/" name="main">
-    <ruletest id="hibernate4-xml-test" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    <ruletest id="{$rulesetId}-test" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
 
         <xsl:if test="string-length($testFileStub) > 0">
@@ -20,7 +21,7 @@
         </xsl:if>
 
         <testDataPath>
-            <xsl:value-of select="$outputDirectory"/>
+            <xsl:value-of select="concat('data/', $rulesetId)"/>
         </testDataPath>
         <ruleset>
             <rules>
@@ -75,12 +76,18 @@
     <xsl:param name="fileElement"/>
     <xsl:variable name="filename" select="./@filename"/>
     <xsl:variable name="filenameGenerated" select="replace($filename, '\{\*\}', '')"/>
-    <xsl:value-of select="concat('cp ', $testFileStub, ' ', $outputDirectory, '/', $filenameGenerated)"/><xsl:text>
+    <xsl:value-of select="concat('cp ', $testFileStub, ' ', $outputDirectory, '/data/', $rulesetId, '/', $filenameGenerated)"/><xsl:text>
 </xsl:text>
 </xsl:template>
 
 <xsl:template name="generate-test-files">
+<xsl:text disable-output-escaping="yes">
+        &lt;!--
+</xsl:text>
     <file-copy-commands>
+<xsl:text>
+</xsl:text>
+<xsl:value-of select="concat('mkdir -p ', $outputDirectory, '/data/', $rulesetId)"/>
 <xsl:text>
 </xsl:text>
 <xsl:for-each select="//windup:when//windup:file">
@@ -89,6 +96,9 @@
 </xsl:call-template>
 </xsl:for-each>
     </file-copy-commands>
+    <xsl:text disable-output-escaping="yes">
+        --&gt;
+    </xsl:text>
 </xsl:template>
 
 

--- a/scripts/tests/test_generation_command.sh
+++ b/scripts/tests/test_generation_command.sh
@@ -1,11 +1,29 @@
 #!/bin/bash
 
+usage()
+{
+  echo
+  echo "Usage:"
+  echo " test_generation_command.sh <path to new rules folder> <path to Saxon HE jar file>"
+  echo
+  exit 1
+}
+
+if [ $# -ne 2 ] ; then
+    usage
+fi
+RULES_BASEDIR=$1
+SAXONHE_PATH=$2
+for rulesetfilepath in $(ls $RULES_BASEDIR*.{windup,rhamt}.xml 2>/dev/null); do
+ if [ ! -f $RULES_BASEDIR"tests/$(basename -- "$rulesetfilepath" .xml).test.xml" ]; then
 # Just an example, modify to suit your environment
-java -jar ~/javadevtools/saxon/saxon9he.jar \
- -s:./rules-reviewed/technology-usage/3rd-party.windup.xml \
+java -jar $SAXONHE_PATH \
+ -s:$rulesetfilepath \
  -xsl:./scripts/tests/create-tests.xslt \
  testFileStub=rules-reviewed/eap7/tests/data/embedded-framework-libraries/jboss-seam-2.jar \
- outputDirectory=./target/testdata  \
+ outputDirectory="$RULES_BASEDIR"tests \
  ruleIDPattern=.* \
-  -o:test.xml
+ -o:"$RULES_BASEDIR"tests/$(basename -- "$rulesetfilepath" .xml).test.xml
+ fi
+done
 


### PR DESCRIPTION
Changes to `create-tests.xslt`
* added variable for ruleset ID
* added `mkdir` command for data test
* changed `cp` target path to be 'compliant' with our path pattern
* set `<testDataPath>` value
* commented `<file-copy-commands>` section so that user can copy&paste commands in shell

Changes to `test_generation_command.sh` 
* loop on input folder to search for missing rulesets test file
* rules folder to work on as input parameter
* Saxon HE path as input parameter
* output directory for tests is `test` folder inside rules folder
* ruleset test file now has the same prefix as the ruleset it refers to
* simple usage output when missing parameter